### PR TITLE
Refactor REST modules and added new extentions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+## Version 2.1.3 - 09/06/25
+Core Updates:
+
+1. Implemented data conversion between with 2 new methods:
+  - Active List to Dictionary data structures
+  - Dictionary to Active List data structures
+
+2. Lazy Initialization
+Modules now initialize on first access for performance
+
+3. Renamed functions:
+  - All `_import` functions to `import_data`
+  - activeLists function `list` now named `lists`

--- a/examples/import_resources.txt
+++ b/examples/import_resources.txt
@@ -1,4 +1,4 @@
-# _import resource "action"
+# import_data resource "action"
 ## The imported resources conflict
 ## with the existing resources because they have the same ID.
 {

--- a/kuma/rest/__init__.py
+++ b/kuma/rest/__init__.py
@@ -56,6 +56,9 @@ class KumaRestAPI(KumaRestAPIBase):
             return self._modules[name]
         raise AttributeError(name)
 
+    def __dir__(self):
+        return sorted(set(super().__dir__()) | set(self._module_classes.keys()))
+
     # Расширенные функции
     #
 

--- a/kuma/rest/__init__.py
+++ b/kuma/rest/__init__.py
@@ -20,6 +20,25 @@ from .users import KumaRestAPIUsers
 class KumaRestAPI(KumaRestAPIBase):
     """Kaspersky Unified Monitoring and Analytics REST API"""
 
+    _module_classes = {
+        "active_lists": KumaRestAPIActiveLists,
+        "alerts": KumaRestAPIAlerts,
+        "assets": KumaRestAPIAssets,
+        "context_tables": KumaRestAPIContextTables,
+        "dictionaries": KumaRestAPIDictionaries,
+        "events": KumaRestAPIEvents,
+        "folders": KumaRestAPIFolders,
+        "incidents": KumaRestAPIIncidents,
+        "reports": KumaRestAPIReports,
+        "resources": KumaRestAPIResources,
+        "services": KumaRestAPIServices,
+        "settings": KumaRestAPISettings,
+        "system": KumaRestAPISystem,
+        "tasks": KumaRestAPITasks,
+        "tenants": KumaRestAPITenants,
+        "users": KumaRestAPIUsers,
+    }
+
     def __init__(
         self,
         url: str,
@@ -27,29 +46,19 @@ class KumaRestAPI(KumaRestAPIBase):
         verify,
         timeout: int = KumaRestAPIBase.DEFAULT_TIMEOUT,
     ):
-        # Инициализируем родительский класс
         super().__init__(url, token, verify, timeout)
+        self._modules = {}
 
-        # Основные модули
-        self.active_lists = KumaRestAPIActiveLists(self)
-        self.alerts = KumaRestAPIAlerts(self)
-        self.assets = KumaRestAPIAssets(self)
-        self.context_tables = KumaRestAPIContextTables(self)
-        self.dictionaries = KumaRestAPIDictionaries(self)
-        self.events = KumaRestAPIEvents(self)
-        self.folders = KumaRestAPIFolders(self)
-        self.incidents = KumaRestAPIIncidents(self)
-        self.reports = KumaRestAPIReports(self)
-        self.resources = KumaRestAPIResources(self)
-        self.services = KumaRestAPIServices(self)
-        self.settings = KumaRestAPISettings(self)
-        self.system = KumaRestAPISystem(self)
-        self.tasks = KumaRestAPITasks(self)
-        self.tenants = KumaRestAPITenants(self)
-        self.users = KumaRestAPIUsers(self)
+    def __getattr__(self, name):
+        if name in self._module_classes:
+            if name not in self._modules:
+                self._modules[name] = self._module_classes[name](self)
+            return self._modules[name]
+        raise AttributeError(name)
 
-        # Расширенные функции
-        #
+    # Расширенные функции
+    #
 
 
-__all__ = ["KumaAPI"]
+KumaAPI = KumaRestAPI
+__all__ = ["KumaRestAPI", "KumaAPI"]

--- a/kuma/rest/_base.py
+++ b/kuma/rest/_base.py
@@ -176,3 +176,10 @@ class KumaRestAPIBase:
         if isinstance(time_value, int):
             return datetime.fromtimestamp(time_value).isoformat()
         return time_value
+
+
+class KumaRestAPIModule:
+    """Base class for REST API modules."""
+
+    def __init__(self, base: "KumaRestAPIBase") -> None:
+        self._base = base

--- a/kuma/rest/active_lists.py
+++ b/kuma/rest/active_lists.py
@@ -1,13 +1,15 @@
 from typing import Dict, List, Optional, Tuple, Union
 
+from ._base import KumaRestAPIModule
 
-class KumaRestAPIActiveLists:
+
+class KumaRestAPIActiveLists(KumaRestAPIModule):
     """
     Методы для работы с активными списками
     """
 
     def __init__(self, base):
-        self._base = base
+        super().__init__(base)
 
     def lists(self, correlator_id: str) -> tuple[int, list | str]:
         """

--- a/kuma/rest/active_lists.py
+++ b/kuma/rest/active_lists.py
@@ -1,4 +1,5 @@
-from typing import Dict, List, Optional, Tuple, Union
+import json
+from typing import Dict, Tuple, Union
 
 from ._base import KumaRestAPIModule
 
@@ -21,7 +22,7 @@ class KumaRestAPIActiveLists(KumaRestAPIModule):
             "GET", "activeLists", params={"correlatorID": correlator_id}
         )
 
-    def _import(
+    def import_data(
         self, correlator_id: str, format: str, data: str, **kwargs
     ) -> tuple[int, Union[str, list]]:
         """
@@ -82,3 +83,94 @@ class KumaRestAPIActiveLists(KumaRestAPIModule):
         return self._base._make_request(
             "GET", f"services/{correlator_id}/activeLists/scan/{active_list_id}"
         )
+
+    # Extended function
+
+    def to_dictionary(
+        self,
+        correlator_id: str,
+        active_list_id: str,
+        dictionary_id: str,
+        active_list_key: str = "key",
+        dictionary_key: str = "key",
+        need_reload: int = 0,
+    ) -> Tuple[int, Dict | str]:
+        """
+        Converts active sheet data into an existing dictionary,
+        with the ability to change the key column.
+        correlator_id* (str): Service ID
+        active_list_id* (str): Source AL resource id
+        dictionary_id* (str): Destination Dict. resource id
+        dictionary_key: Key column name of Dictionary which will have values from key column of Active List.
+        active_list_key: Column name of Active List which will be key column in Dictionary.
+        """
+        if not correlator_id:
+            raise ValueError("Correlator id must be specified")
+        if not active_list_id:
+            raise ValueError("Active List id must be specified")
+        if not dictionary_id:
+            raise ValueError("Dictionary id must be specified")
+
+        download_id = self.export(
+            correlator_id=correlator_id, active_list_id=active_list_id
+        )[1]["id"]
+        al_content_json = self.download(download_id)[1]
+        al_content = [json.loads(line) for line in al_content_json.splitlines()]
+
+        if active_list_key != "key" and active_list_key not in al_content[0].get(
+            "record"
+        ):
+            raise ValueError(
+                "Active List column name for Dictionary key must be equal 'key' or exist in Active List"
+            )
+
+        dict_data = self._base.dictionaries.content(dictionary_id)[1]
+        dict_unique_values = frozenset(
+            row.split(",")[0] for row in dict_data.splitlines()[1:]
+        )
+        dict_headers = dict_data.splitlines()[0].split(",")
+        del dict_headers[0]
+
+        if active_list_key == "key":
+            dict_data += self._get_data_with_key_column(
+                dict_unique_values, al_content, dict_headers
+            )
+        else:
+            dict_data += self._get_data_with_unique_column(
+                dict_unique_values,
+                al_content,
+                dict_headers,
+                active_list_key,
+                dictionary_key,
+            )
+
+        return self._base.dictionaries.update(
+            dictionary_id=dictionary_id,
+            csv=dict_data,
+            need_reload=need_reload,
+        )
+
+    def _get_data_with_key_column(self, dict_unique_values, al_content, dict_headers):
+        dict_data = ""
+        for row in al_content:
+            if (key := row["key"]) not in dict_unique_values:
+                record = row["record"]
+                dict_data += f"{key},{','.join([record.get(header, '') for header in dict_headers])}\n"
+        return dict_data
+
+    def _get_data_with_unique_column(
+        self,
+        dict_unique_values,
+        al_content,
+        dict_headers,
+        active_list_key,
+        dictionary_key,
+    ):
+        index = dict_headers.index(dictionary_key)
+        dict_headers[index] = "key"
+        dict_data = ""
+        for row in al_content:
+            record = row["record"]
+            if (key := record[active_list_key]) not in dict_unique_values:
+                dict_data += f"{key},{','.join([record.get(header, '') if header != 'key' else row['key'] for header in dict_headers])}\n"
+        return dict_data

--- a/kuma/rest/alerts.py
+++ b/kuma/rest/alerts.py
@@ -1,13 +1,15 @@
 from typing import Any, Dict, List, Optional, Tuple, Union
 
+from ._base import KumaRestAPIModule
 
-class KumaRestAPIAlerts:
+
+class KumaRestAPIAlerts(KumaRestAPIModule):
     """
     Методы для работы с алертами
     """
 
     def __init__(self, base):
-        self._base = base
+        super().__init__(base)
 
     def search(self, **kwargs) -> Tuple[int, bytes | str]:
         """
@@ -103,28 +105,6 @@ class KumaRestAPIAlerts:
         """
         json = {"alertID": alert_id, "eventID": event_id}
         return self._base._make_request("POST", f"alerts/unlink-event", json=json)
-
-    ### ext
-
-    def search(self, **kwargs) -> Tuple[int, bytes | str]:
-        """
-        Searching alerts from KUMA
-        Args:
-            page (int): Listing page of result (250 alerts per page)
-            id (List[str]): Search for specified alerts
-            tenantID (str): Tenant filter
-            name (str): Case-insensetine name regex filter
-            timestampField (str): lastSeen|firtsSeen for from-to order
-            from (str): RFC3339 Lower limit
-            to (str): RFC3339 Upper limit
-            status (str): new|assigned|closed|escalated
-            withEvents (str): Include normalized JSON (HEAVY)
-            withAffected (str): Include assets and accounts
-        """
-        params = {
-            **kwargs,
-        }
-        return self._base._make_request("GET", "alerts", params=params)
 
     # Extended
 

--- a/kuma/rest/assets.py
+++ b/kuma/rest/assets.py
@@ -1,13 +1,15 @@
 from typing import Any, Dict, List, Optional, Tuple, Union
 
+from ._base import KumaRestAPIModule
 
-class KumaRestAPIAssets:
+
+class KumaRestAPIAssets(KumaRestAPIModule):
     """
     Методы для работы с активами
     """
 
     def __init__(self, base):
-        self._base = base
+        super().__init__(base)
 
     def search(self, **kwargs) -> Tuple[int, List | str]:
         """Searchin assets by provided filter

--- a/kuma/rest/context_tables.py
+++ b/kuma/rest/context_tables.py
@@ -1,13 +1,15 @@
 from typing import Dict, List, Optional, Tuple, Union
 
+from ._base import KumaRestAPIModule
 
-class KumaRestAPIContextTables:
+
+class KumaRestAPIContextTables(KumaRestAPIModule):
     """
     Методы для работы с контекстными таблицами (живут на корреляторах)
     """
 
     def __init__(self, base):
-        self._base = base
+        super().__init__(base)
 
     def list(
         self,

--- a/kuma/rest/context_tables.py
+++ b/kuma/rest/context_tables.py
@@ -47,7 +47,7 @@ class KumaRestAPIContextTables(KumaRestAPIModule):
             params["contextTableName"] = context_table_name
         return self._base._make_request("GET", "contextTables/export", params=params)
 
-    def _import(
+    def import_data(
         self, correlator_id: str, format: str, data: str, **kwargs
     ) -> tuple[int, str]:
         """

--- a/kuma/rest/dictionaries.py
+++ b/kuma/rest/dictionaries.py
@@ -1,4 +1,6 @@
+import csv
 import os
+from io import StringIO
 from typing import Dict, List, Optional, Tuple, Union
 
 from ._base import APIError, KumaRestAPIModule
@@ -95,9 +97,9 @@ class KumaRestAPIDictionaries(KumaRestAPIModule):
 
     def csv_to_json(self, csv_data: str) -> Dict:
         """
-        Преобразует CSV словаря в список JSON объектов с обработкой ошибок.
+        Transform CSV in JSON list.
         Args:
-            csv_data: CSV строка с заголовками из контента dictionaries
+            csv_data: CSV string rows from dictionary content.
         """
         try:
             lines = [line.strip() for line in csv_data.split("\n") if line.strip()]
@@ -118,3 +120,71 @@ class KumaRestAPIDictionaries(KumaRestAPIModule):
         except Exception as e:
             self._base.logger.exception(f"Unknown exeption: {e}")
             return None
+
+    def to_active_list(
+        self,
+        dictionary_id: str,
+        correlator_id: str,
+        active_list_id: str,
+        dictionary_key: str = "key",
+        clear: bool = False,
+    ) -> Tuple[int, Dict | str]:
+        """
+        Converts dictionary data to an existing active list,
+            with the ability to change the key column.
+        dictionary_id* (str): Destination Dict. resource id
+        correlator_id* (str): Service ID
+        active_list_id* (str): Source AL resource id
+        dictionary_key (str): Key column name of Dictionary which will have values from key column of Active List.
+        clear (bool, optional): Is need to delete existing values. Defaults to False.
+        """
+        dictionary_data = self._swap_key_column(
+            self.content(dictionary_id)[1], dictionary_key
+        )
+
+        return self._base.active_lists.import_data(
+            correlator_id,
+            "csv",
+            activeListID=active_list_id,
+            keyField=dictionary_key,
+            data=dictionary_data,
+            clear=clear,
+        )
+
+        pass
+
+    def _swap_key_column(self, csv_data, new_key_column):
+        """Function for replacing key field in CSV
+        with uniqueness validation and renaming
+
+        Args:
+            csv_data (str): Data
+            new_key_column (str): Which CSV column should be taken
+        """
+        reader = csv.DictReader(StringIO(csv_data.strip()))
+        rows = list(reader)
+        fieldnames = reader.fieldnames
+        if new_key_column == "key" or new_key_column not in fieldnames:
+            return csv_data
+        new_fieldnames = ["key", "value"] + [
+            f for f in fieldnames if f not in ["key", new_key_column]
+        ]
+        new_rows = []
+        for row in rows:
+            if not row.get(new_key_column):
+                continue
+            new_row = {
+                "key": row[new_key_column],  # Новая колонка -> key
+                "value": row.get("key", ""),  # Старый key -> value
+            }
+            # Добавляем остальные поля (кроме key и new_key_column)
+            for field in row:
+                if field not in ["key", new_key_column, "", None]:
+                    new_row[field] = row[field]
+            new_rows.append(new_row)
+        output = StringIO()
+        writer = csv.DictWriter(output, fieldnames=new_fieldnames)
+        writer.writeheader()
+        writer.writerows(new_rows)
+
+        return output.getvalue()

--- a/kuma/rest/dictionaries.py
+++ b/kuma/rest/dictionaries.py
@@ -1,16 +1,16 @@
 import os
 from typing import Dict, List, Optional, Tuple, Union
 
-from ._base import APIError, KumaRestAPIBase
+from ._base import APIError, KumaRestAPIModule
 
 
-class KumaRestAPIDictionaries(KumaRestAPIBase):
+class KumaRestAPIDictionaries(KumaRestAPIModule):
     """
     Методы для работы со словарями и таблицами
     """
 
     def __init__(self, base):
-        self._base = base
+        super().__init__(base)
 
     def content(self, dictionary_id: str) -> Tuple[int, str]:
         """

--- a/kuma/rest/events.py
+++ b/kuma/rest/events.py
@@ -1,14 +1,16 @@
 from datetime import datetime, timedelta, timezone
 from typing import Dict, List, Optional, Tuple, Union
 
+from ._base import KumaRestAPIModule
 
-class KumaRestAPIEvents:
+
+class KumaRestAPIEvents(KumaRestAPIModule):
     """
     Методы для работы с событиями
     """
 
     def __init__(self, base):
-        self._base = base
+        super().__init__(base)
 
     def search(
         self,

--- a/kuma/rest/folders.py
+++ b/kuma/rest/folders.py
@@ -1,13 +1,15 @@
 from typing import Any, Dict, List, Optional, Tuple, Union
 
+from ._base import KumaRestAPIModule
 
-class KumaRestAPIFolders:
+
+class KumaRestAPIFolders(KumaRestAPIModule):
     """
     Методы для работы с алертами
     """
 
     def __init__(self, base):
-        self._base = base
+        super().__init__(base)
 
     def search(self, tenants_ids: List[str], **kwargs) -> Tuple[int, List | str]:
         """

--- a/kuma/rest/incidents.py
+++ b/kuma/rest/incidents.py
@@ -1,13 +1,15 @@
 from typing import Any, Dict, List, Optional, Tuple, Union
 
+from ._base import KumaRestAPIModule
 
-class KumaRestAPIIncidents:
+
+class KumaRestAPIIncidents(KumaRestAPIModule):
     """
     Методы для работы с алертами
     """
 
     def __init__(self, base):
-        self._base = base
+        super().__init__(base)
 
     def search(self, **kwargs) -> Tuple[int, bytes | str]:
         """

--- a/kuma/rest/reports.py
+++ b/kuma/rest/reports.py
@@ -1,13 +1,15 @@
 from typing import Any, Dict, List, Optional, Tuple, Union
 
+from ._base import KumaRestAPIModule
 
-class KumaRestAPIReports:
+
+class KumaRestAPIReports(KumaRestAPIModule):
     """
     Методы для работы с алертами
     """
 
     def __init__(self, base):
-        self._base = base
+        super().__init__(base)
 
     def search(self, tenants_ids: List[str], **kwargs) -> Tuple[int, List | str]:
         """

--- a/kuma/rest/resources.py
+++ b/kuma/rest/resources.py
@@ -1,13 +1,15 @@
 from typing import Any, Dict, List, Optional, Tuple, Union
 
+from ._base import KumaRestAPIModule
 
-class KumaRestAPIResources:
+
+class KumaRestAPIResources(KumaRestAPIModule):
     """
     Методы для работы с алертами
     """
 
     def __init__(self, base):
-        self._base = base
+        super().__init__(base)
 
     def search(self, **kwargs) -> Tuple[int, List | str]:
         """

--- a/kuma/rest/resources.py
+++ b/kuma/rest/resources.py
@@ -51,7 +51,7 @@ class KumaRestAPIResources(KumaRestAPIModule):
         json = {"ids": resources_ids, "password": password, "tenantID": tenant_id}
         return self._base._make_request("POST", "resources/export", json=json)
 
-    def _import(
+    def import_data(
         self,
         file_id: str,
         tenant_id: str,
@@ -81,7 +81,7 @@ class KumaRestAPIResources(KumaRestAPIModule):
         password: str = "Kuma_secret_p@$$w0rd",
     ) -> Tuple[int, List | str]:
         """
-        View content of uploaded resource file, recomended to use before _import
+        View content of uploaded resource file, recomended to use before import_data
         Args:
             file_id* (str): Uploaded file UUID returned by Core
             password (str): File open password

--- a/kuma/rest/services.py
+++ b/kuma/rest/services.py
@@ -1,13 +1,15 @@
 from typing import Dict, List, Optional, Tuple, Union
 
+from ._base import KumaRestAPIModule
 
-class KumaRestAPIServices:
+
+class KumaRestAPIServices(KumaRestAPIModule):
     """
     Методы для работы с сервисами
     """
 
     def __init__(self, base):
-        self._base = base
+        super().__init__(base)
 
     def search(
         self,

--- a/kuma/rest/settings.py
+++ b/kuma/rest/settings.py
@@ -1,13 +1,15 @@
 from typing import Dict, List, Optional, Tuple, Union
 
+from ._base import KumaRestAPIModule
 
-class KumaRestAPISettings:
+
+class KumaRestAPISettings(KumaRestAPIModule):
     """
     Методы для работы с настройками Ядра
     """
 
     def __init__(self, base):
-        self._base = base
+        super().__init__(base)
 
     def view(self, id: str) -> tuple[int, dict | str]:
         """

--- a/kuma/rest/system.py
+++ b/kuma/rest/system.py
@@ -1,13 +1,15 @@
 from typing import Dict, List, Optional, Tuple, Union
 
+from ._base import KumaRestAPIModule
 
-class KumaRestAPISystem:
+
+class KumaRestAPISystem(KumaRestAPIModule):
     """
     Методы для работы с ядром
     """
 
     def __init__(self, base):
-        self._base = base
+        super().__init__(base)
 
     def backup(
         self,

--- a/kuma/rest/tasks.py
+++ b/kuma/rest/tasks.py
@@ -1,13 +1,15 @@
 from typing import Dict, List, Optional, Tuple, Union
 
+from ._base import KumaRestAPIModule
 
-class KumaRestAPITasks:
+
+class KumaRestAPITasks(KumaRestAPIModule):
     """
     Методы для работы с отложенными задачами
     """
 
     def __init__(self, base):
-        self._base = base
+        super().__init__(base)
 
     def create(self, task: dict) -> Tuple[int, List | str]:
         """

--- a/kuma/rest/tenants.py
+++ b/kuma/rest/tenants.py
@@ -1,13 +1,15 @@
 from typing import Dict, List, Optional, Tuple, Union
 
+from ._base import KumaRestAPIModule
 
-class KumaRestAPITenants:
+
+class KumaRestAPITenants(KumaRestAPIModule):
     """
     Методы для работы с тенантами
     """
 
     def __init__(self, base):
-        self._base = base
+        super().__init__(base)
 
     def search(self, **kwargs) -> Tuple[int, List | str]:
         """

--- a/kuma/rest/users.py
+++ b/kuma/rest/users.py
@@ -1,13 +1,15 @@
 from typing import Dict, List, Optional, Tuple, Union
 
+from ._base import KumaRestAPIModule
 
-class KumaRestAPIUsers:
+
+class KumaRestAPIUsers(KumaRestAPIModule):
     """
     Методы для работы с пользователями
     """
 
     def __init__(self, base):
-        self._base = base
+        super().__init__(base)
 
     def search(self, **kwargs) -> Tuple[int, List | str]:
         """


### PR DESCRIPTION
## Summary
- add `KumaRestAPIModule` base class
- make REST modules inherit from it
- remove duplicated `search` in `alerts`
- lazily construct modules in `KumaRestAPI`
- expose `KumaAPI` alias

## Testing
- `python -m compileall -q kuma`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846ec5e71a883238530e93f0bf8c405