### PR TITLE
Feat/p39 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 [![PyPI](https://img.shields.io/pypi/v/kuma-api?logo=pypi&logoColor=white)](https://pypi.org/project/kuma-api)
 [![GitHub](https://img.shields.io/badge/GitHub-repo-181717?logo=github&logoColor=white)](https://github.com/Mixtol/kapi)
-
+![Python Version](https://img.shields.io/badge/python-3.9%2B-green)
+[![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 
 ## Описание
 

--- a/kuma/private.py
+++ b/kuma/private.py
@@ -2,7 +2,7 @@ import json
 import urllib
 import urllib.parse
 import uuid
-from typing import Any, Tuple
+from typing import Any, Optional, Tuple, Union
 
 import requests
 
@@ -207,7 +207,9 @@ class KumaPrivateAPI:
             f"{self.url}/api/private/resources/correlator?tenantID={tenant_id}"
         ).json()
 
-    def get_tenant_services(self, tenant_id: str, kind: str) -> list | None:
+    def get_tenant_services(
+        self, tenant_id: str, kind: str
+    ) -> Optional[list]:
         """Функция возвращающая сервисы заданного типа по тенанту
         Args:
             tenant_id (str): tenantID
@@ -221,11 +223,13 @@ class KumaPrivateAPI:
         if response.status_code in (200, 204):
             return response.json()
 
-    def get_resource(self, id: str = None, kind: str | None = None) -> dict:
+    def get_resource(self, id: str = None, kind: Optional[str] = None) -> dict:
         response = self.session.get(f"{self.url}/api/private/resources/{kind}/{id}")
         return response.json() if response.status_code == 200 else response.text
 
-    def get_resources(self, kind: str | None = None, tenant_id: str = "") -> list:
+    def get_resources(
+        self, kind: Optional[str] = None, tenant_id: str = ""
+    ) -> list:
         response = self.session.get(
             f"{self.url}/api/private/resources/{kind}?tenantID={tenant_id}"
         )
@@ -279,7 +283,7 @@ class KumaPrivateAPI:
         )
         return response.json() if response.status_code == 200 else response.text
 
-    def get_all_services(self, kind: str | None = None):
+    def get_all_services(self, kind: Optional[str] = None):
         """The function for receiving all instance services"""
         if kind:
             url = f"{self.url}/api/private/services/?pattern=&size=1000&kind={kind}"
@@ -289,7 +293,7 @@ class KumaPrivateAPI:
         response = self.session.get(url)
         return response.json() if response.status_code == 200 else response.text
 
-    def get_service_id_by_resouce_id(self, resource_id) -> str | None:
+    def get_service_id_by_resouce_id(self, resource_id) -> Optional[str]:
         response = self.session.get(f"{self.url}/api/private/services/")
         for service in response.json():
             if service["resourceID"] == resource_id:
@@ -453,7 +457,7 @@ class KumaPrivateAPI:
 
     def get_folder_id_by_name(
         self, folder_name, sub_kind, tenant_id, parent_id
-    ) -> str | None:
+    ) -> Optional[str]:
         response_json = self.session.get(
             f"{self.url}/api/private/folders/?subKind={sub_kind}"
         ).json()
@@ -703,7 +707,7 @@ class KumaPrivateAPI:
         correlator_data["payload"]["rules"] = updated_rules
         return self.update_resource(correlator_data)
 
-    def move_content(self, folderID, resourceIDs: list | str):
+    def move_content(self, folderID, resourceIDs: Union[list, str]):
         """Функция перемещения из папки в папку контента"""
         url = self.url + "/api/private/misc/resource/move"
         payload = {
@@ -721,7 +725,7 @@ class KumaPrivateAPI:
         self,
         ids: list,
         tenant_id: str,
-        password: str | None = None,
+        password: Optional[str] = None,
         file_path: str = "exported_content",
     ):
         """
@@ -808,7 +812,7 @@ class KumaPrivateAPI:
 
     def get_active_list_content(
         self, correlator_service_id: str, active_list_id: str
-    ) -> str | Any:
+    ) -> Union[str, Any]:
         """
         Старая функция скачивает файл, потом разшифровывает его и возвращает словарь.
 

--- a/kuma/rest/__init__.py
+++ b/kuma/rest/__init__.py
@@ -1,3 +1,5 @@
+from typing import Union
+
 from kuma.rest._base import KumaRestAPIBase
 from kuma.rest.active_lists import KumaRestAPIActiveLists
 from kuma.rest.alerts import KumaRestAPIAlerts
@@ -43,7 +45,7 @@ class KumaRestAPI(KumaRestAPIBase):
         self,
         url: str,
         token: str,
-        verify: bool | str,
+        verify: Union[bool, str],
         timeout: int = KumaRestAPIBase.DEFAULT_TIMEOUT,
     ):
         super().__init__(url, token, verify, timeout)

--- a/kuma/rest/_base.py
+++ b/kuma/rest/_base.py
@@ -31,7 +31,7 @@ class KumaRestAPIBase:
         self,
         url: str,
         token: str,
-        verify: bool | str = False,
+        verify: Union[bool, str] = False,
         timeout: int = DEFAULT_TIMEOUT,
         logger: Optional[logging.Logger] = None,
     ):
@@ -83,7 +83,7 @@ class KumaRestAPIBase:
             {"Authorization": f"Bearer {token}", "Accept": "application/json"}
         )
 
-    def _configure_ssl(self, verify: bool | str) -> None:
+    def _configure_ssl(self, verify: Union[bool, str]) -> None:
         """Configure SSL verification settings."""
         self.verify = verify
         if not self.verify:
@@ -172,7 +172,7 @@ class KumaRestAPIBase:
             raise APIError(f"Response parsing failed: {exception}")
 
     @staticmethod
-    def format_time(time_value: int | Any) -> int | Any:
+    def format_time(time_value: Union[int, Any]) -> Any:
         if isinstance(time_value, int):
             return datetime.fromtimestamp(time_value).isoformat()
         return time_value
@@ -192,6 +192,6 @@ class KumaRestAPIModule:
         """Proxy request call to the parent client."""
         return self._base._make_request(*args, **kwargs)
 
-    def format_time(self, time_value: int | Any) -> int | Any:
+    def format_time(self, time_value: Union[int, Any]) -> Any:
         """Proxy ``format_time`` to the parent client."""
         return self._base.format_time(time_value)

--- a/kuma/rest/active_lists.py
+++ b/kuma/rest/active_lists.py
@@ -7,7 +7,7 @@ from kuma.rest._base import KumaRestAPIModule
 class KumaRestAPIActiveLists(KumaRestAPIModule):
     """Methods for Active Lists."""
 
-    def lists(self, correlator_id: str) -> tuple[int, list | str]:
+    def lists(self, correlator_id: str) -> Tuple[int, Union[list, str]]:
         """
         Gets current active lists on correlator.
         Args:
@@ -19,7 +19,7 @@ class KumaRestAPIActiveLists(KumaRestAPIModule):
 
     def import_data(
         self, correlator_id: str, format: str, data: str, **kwargs
-    ) -> tuple[int, Union[str, list]]:
+    ) -> Tuple[int, Union[str, list]]:
         """
             Method for importing JSON(with out commas), CSV, TSV to Correaltor AL
         Args:
@@ -48,7 +48,7 @@ class KumaRestAPIActiveLists(KumaRestAPIModule):
 
     def export(
         self, correlator_id: str, active_list_id: str
-    ) -> Tuple[int, bytes | str]:
+    ) -> Tuple[int, Union[bytes, str]]:
         """
         Generatind AL file ID for download file method.
         Args:
@@ -63,7 +63,7 @@ class KumaRestAPIActiveLists(KumaRestAPIModule):
 
     def scan(
         self, correlator_id: str, active_list_id: str, **kwargs
-    ) -> Tuple[int, Dict | str]:
+    ) -> Tuple[int, Union[Dict, str]]:
         """
         Scan active list content withouts keys (For some extraordinary shit).
         Args:
@@ -89,7 +89,7 @@ class KumaRestAPIActiveLists(KumaRestAPIModule):
         active_list_key: str = "key",
         need_reload: int = 0,
         clear: bool = False,
-    ) -> Tuple[int, Dict | str]:
+    ) -> Tuple[int, Union[Dict, str]]:
         """
         Converts active sheet data into an existing dictionary,
         with the ability to change the key column.

--- a/kuma/rest/alerts.py
+++ b/kuma/rest/alerts.py
@@ -1,11 +1,11 @@
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, Union
 
 from kuma.rest._base import KumaRestAPIModule
 
 
 class KumaRestAPIAlerts(KumaRestAPIModule):
     """Methods for Alerts."""
-    def search(self, **kwargs) -> Tuple[int, bytes | str]:
+    def search(self, **kwargs) -> Tuple[int, Union[bytes, str]]:
         """
         Searching alerts from KUMA
         Args:
@@ -26,7 +26,7 @@ class KumaRestAPIAlerts(KumaRestAPIModule):
         }
         return self._make_request("GET", "alerts", params=params)
 
-    def assign(self, alerts_ids: list, user_id: str) -> Tuple[int, bytes | str]:
+    def assign(self, alerts_ids: list, user_id: str) -> Tuple[int, Union[bytes, str]]:
         """Alert assign method
         Args:
             alerts_ids (list): Alerts UUID list
@@ -55,7 +55,7 @@ class KumaRestAPIAlerts(KumaRestAPIModule):
         json = {"alertID": alert_id, "comment": comment}
         return self._make_request("POST", "alerts/comment", json=json)
 
-    def get(self, alert_id: str) -> Tuple[int, Dict | str]:
+    def get(self, alert_id: str) -> Tuple[int, Union[Dict, str]]:
         """Gets specified alert data
         Args:
             alert_id (str): Alert UUID
@@ -69,7 +69,7 @@ class KumaRestAPIAlerts(KumaRestAPIModule):
         event_id: str,
         event_timestamp: int,
         comment: str,
-    ) -> Tuple[int, Dict | str]:
+    ) -> Tuple[int, Union[Dict, str]]:
         """Linking event from storage to alert
         Args:
             alert_id (str): Alert UUID
@@ -91,7 +91,7 @@ class KumaRestAPIAlerts(KumaRestAPIModule):
         self,
         alert_id: str,
         event_id: str,
-    ) -> Tuple[int, Dict | str]:
+    ) -> Tuple[int, Union[Dict, str]]:
         """Unlinks event from  alert
         Args:
             alert_id (str): Alert UUID
@@ -102,7 +102,7 @@ class KumaRestAPIAlerts(KumaRestAPIModule):
 
     # Extended
 
-    def searchp(self, limit: int = 250, **kwargs) -> Tuple[int, list | str]:
+    def searchp(self, limit: int = 250, **kwargs) -> Tuple[int, Union[list, str]]:
         """
         Search with pagination, if more 250 is needed
         Args:

--- a/kuma/rest/assets.py
+++ b/kuma/rest/assets.py
@@ -1,11 +1,11 @@
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, Union
 
 from kuma.rest._base import KumaRestAPIModule
 
 
 class KumaRestAPIAssets(KumaRestAPIModule):
     """Methods for Assets."""
-    def search(self, **kwargs) -> Tuple[int, List | str]:
+    def search(self, **kwargs) -> Tuple[int, Union[List, str]]:
         """
         Searching assets by provided filter.
 
@@ -26,7 +26,7 @@ class KumaRestAPIAssets(KumaRestAPIModule):
         assets_ids: List[str],
         assets_ips: List[str],
         tenant_id: str,
-    ) -> Tuple[int, Dict | str]:
+    ) -> Tuple[int, Union[Dict, str]]:
         """
         Method for deleting tenant assets.
 
@@ -44,7 +44,7 @@ class KumaRestAPIAssets(KumaRestAPIModule):
         }
         return self._make_request("POST", "assets/delete", json=json)
 
-    def create(self, assets: List[Dict], tenant_id: str) -> Tuple[int, Dict | str]:
+    def create(self, assets: List[Dict], tenant_id: str) -> Tuple[int, Union[Dict, str]]:
         """
         Import/create assets from JSON, see examples.
 

--- a/kuma/rest/context_tables.py
+++ b/kuma/rest/context_tables.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Union
 
 from kuma.rest._base import KumaRestAPIModule
 
@@ -8,7 +8,7 @@ class KumaRestAPIContextTables(KumaRestAPIModule):
     def list(
         self,
         correlator_id: str,
-    ) -> tuple[int, dict | str | bytes]:
+    ) -> Tuple[int, Union[dict, str, bytes]]:
         """
         Get context tables from correlator.
         Args:
@@ -24,7 +24,7 @@ class KumaRestAPIContextTables(KumaRestAPIModule):
         correlator_id: str,
         context_table_id: Optional[str] = None,
         context_table_name: Optional[str] = None,
-    ) -> Tuple[int, bytes | str]:
+    ) -> Tuple[int, Union[bytes, str]]:
         """
         Download context table data from correlator
         Args:
@@ -43,7 +43,7 @@ class KumaRestAPIContextTables(KumaRestAPIModule):
 
     def import_data(
         self, correlator_id: str, format: str, data: str, **kwargs
-    ) -> tuple[int, str]:
+    ) -> Tuple[int, str]:
         """
         Method for importing JSON(with out commas), CSV, TSV to Correaltor AL
         Args:

--- a/kuma/rest/dictionaries.py
+++ b/kuma/rest/dictionaries.py
@@ -1,7 +1,7 @@
 import csv
 import os
 from io import StringIO
-from typing import Dict, Tuple
+from typing import Dict, Tuple, Union
 
 from kuma.rest._base import APIError, KumaRestAPIModule
 
@@ -122,7 +122,7 @@ class KumaRestAPIDictionaries(KumaRestAPIModule):
         active_list_id: str,
         dictionary_key: str = "key",
         clear: bool = False,
-    ) -> Tuple[int, Dict | str]:
+    ) -> Tuple[int, Union[Dict, str]]:
         """
         Converts dictionary data to an existing active list,
             with the ability to change the key column.

--- a/kuma/rest/events.py
+++ b/kuma/rest/events.py
@@ -36,7 +36,7 @@ class KumaRestAPIEvents(KumaRestAPIModule):
         }
         return self._make_request("POST", "events", json=json)
 
-    def get_clusters(self, **kwargs) -> tuple[int, dict | str | bytes]:
+    def get_clusters(self, **kwargs) -> Tuple[int, Union[dict, str, bytes]]:
         """
         List storages clusters for events.
         Args:
@@ -46,7 +46,7 @@ class KumaRestAPIEvents(KumaRestAPIModule):
             page (int, optional): Pagination page number
 
         Returns:
-            tuple[int, dict | str | bytes]: _description_
+            Tuple[int, Union[dict, str, bytes]]: _description_
         """
         params = {**kwargs}
         return self._make_request("GET", "events/clusters", params=params)

--- a/kuma/rest/folders.py
+++ b/kuma/rest/folders.py
@@ -1,11 +1,13 @@
-from typing import List, Tuple
+from typing import List, Tuple, Union
 
 from kuma.rest._base import KumaRestAPIModule
 
 
 class KumaRestAPIFolders(KumaRestAPIModule):
     """Methods for Folders."""
-    def search(self, tenants_ids: List[str], **kwargs) -> Tuple[int, List | str]:  # TODO: Use tenants_ids
+    def search(
+        self, tenants_ids: List[str], **kwargs
+    ) -> Tuple[int, Union[List, str]]:  # TODO: Use tenants_ids
         """
         Searching folders info
         Args:

--- a/kuma/rest/incidents.py
+++ b/kuma/rest/incidents.py
@@ -1,11 +1,11 @@
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, Union
 
 from kuma.rest._base import KumaRestAPIModule
 
 
 class KumaRestAPIIncidents(KumaRestAPIModule):
     """Methods for Incidents."""
-    def search(self, **kwargs) -> Tuple[int, bytes | str]:
+    def search(self, **kwargs) -> Tuple[int, Union[bytes, str]]:
         """
         Searching alerts from KUMA
         Args:
@@ -24,7 +24,7 @@ class KumaRestAPIIncidents(KumaRestAPIModule):
         }
         return self._make_request("GET", "incidents", params=params)
 
-    def assign(self, incidents_ids: list, user_id: str) -> Tuple[int, bytes | str]:
+    def assign(self, incidents_ids: list, user_id: str) -> Tuple[int, Union[bytes, str]]:
         """Alert assign method
         Args:
             incidents_ids (list): Incidents INC names list
@@ -43,7 +43,7 @@ class KumaRestAPIIncidents(KumaRestAPIModule):
         json = {"incidentIDs": incidents_ids, "resolution": resolution}
         return self._make_request("POST", "incidents/close", json=json)
 
-    def comment(self, incident_id: str, comment: str) -> Tuple[int, Dict | str]:
+    def comment(self, incident_id: str, comment: str) -> Tuple[int, Union[Dict, str]]:
         """
         Create a comment in alert.
         Args:
@@ -55,7 +55,7 @@ class KumaRestAPIIncidents(KumaRestAPIModule):
 
     def create(
         self, incident: dict, calc_priority: bool = False
-    ) -> Tuple[int, Dict | str]:
+    ) -> Tuple[int, Union[Dict, str]]:
         """
         Creating new incident from JSON data
         Args:
@@ -67,7 +67,7 @@ class KumaRestAPIIncidents(KumaRestAPIModule):
             "POST", f"incidents/create", json=incident, params=params
         )
 
-    def get(self, incident_id: str) -> Tuple[int, Dict | str]:
+    def get(self, incident_id: str) -> Tuple[int, Union[Dict, str]]:
         """Gets specified alert data
         Args:
             incident_id (str): Incident INC id
@@ -76,7 +76,7 @@ class KumaRestAPIIncidents(KumaRestAPIModule):
 
     def link_alert(
         self, incident_id: str, alerts_ids: List[str]
-    ) -> Tuple[int, Dict | str]:
+    ) -> Tuple[int, Union[Dict, str]]:
         """Linking event from storage to alert
         Args:
             incident_id (str): Incident INC id
@@ -87,7 +87,7 @@ class KumaRestAPIIncidents(KumaRestAPIModule):
 
     def unlink_alert(
         self, incident_id: str, alerts_ids: List[str]
-    ) -> Tuple[int, Dict | str]:
+    ) -> Tuple[int, Union[Dict, str]]:
         """Linking event from storage to alert
         Args:
             incident_id (str): Incident INC id

--- a/kuma/rest/reports.py
+++ b/kuma/rest/reports.py
@@ -1,11 +1,13 @@
-from typing import List, Tuple
+from typing import List, Tuple, Union
 
 from kuma.rest._base import KumaRestAPIModule
 
 
 class KumaRestAPIReports(KumaRestAPIModule):
     """Methods for Reports."""
-    def search(self, tenants_ids: List[str], **kwargs) -> Tuple[int, List | str]:
+    def search(
+        self, tenants_ids: List[str], **kwargs
+    ) -> Tuple[int, Union[List, str]]:
         """
         Searching reports info
         Args:

--- a/kuma/rest/resources.py
+++ b/kuma/rest/resources.py
@@ -6,7 +6,7 @@ from kuma.rest._base import KumaRestAPIModule
 class KumaRestAPIResources(KumaRestAPIModule):
     """Methods for Resources."""
 
-    def search(self, **kwargs) -> Tuple[int, List | str]:
+    def search(self, **kwargs) -> Tuple[int, Union[List, str]]:
         """
         Search resources
         Args:
@@ -22,7 +22,7 @@ class KumaRestAPIResources(KumaRestAPIModule):
         }
         return self._make_request("GET", "resources", params=params)
 
-    def download(self, id: str) -> Tuple[int, List | str]:
+    def download(self, id: str) -> Tuple[int, Union[List, str]]:
         """
         Download export file data
         Args:
@@ -35,7 +35,7 @@ class KumaRestAPIResources(KumaRestAPIModule):
         resources_ids: List[str],
         tenant_id: str,
         password: str = "Kuma_secret_p@$$w0rd",
-    ) -> Tuple[int, List | str]:
+    ) -> Tuple[int, Union[List, str]]:
         """
         Generating export file ID for download
         Args:
@@ -52,7 +52,7 @@ class KumaRestAPIResources(KumaRestAPIModule):
         tenant_id: str,
         password: str = "Kuma_secret_p@$$w0rd",
         actions: Optional[Dict] = None,
-    ) -> Tuple[int, List | str]:
+    ) -> Tuple[int, Union[List, str]]:
         """
         Import content file uploded early from /upload method
         Args:
@@ -74,7 +74,7 @@ class KumaRestAPIResources(KumaRestAPIModule):
         self,
         file_id: str,
         password: str = "Kuma_secret_p@$$w0rd",
-    ) -> Tuple[int, List | str]:
+    ) -> Tuple[int, Union[List, str]]:
         """
         View content of uploaded resource file, recommended to use before import_data
         Args:
@@ -87,7 +87,7 @@ class KumaRestAPIResources(KumaRestAPIModule):
         }
         return self._make_request("POST", f"resources/toc", json=json)
 
-    def upload(self, data: Union[bytes, str]) -> Tuple[int, List | str]:
+    def upload(self, data: Union[bytes, str]) -> Tuple[int, Union[List, str]]:
         """
         Download export file data
         Args:
@@ -102,7 +102,7 @@ class KumaRestAPIResources(KumaRestAPIModule):
         self,
         kind: str,
         resource: dict,
-    ) -> Tuple[int, List | str]:
+    ) -> Tuple[int, Union[List, str]]:
         """
         Create resource from JSON
         Args:
@@ -115,7 +115,7 @@ class KumaRestAPIResources(KumaRestAPIModule):
         self,
         kind: str,
         resource: dict,
-    ) -> Tuple[int, List | str]:
+    ) -> Tuple[int, Union[List, str]]:
         """
         Validate resource JSON
         Args:
@@ -124,7 +124,7 @@ class KumaRestAPIResources(KumaRestAPIModule):
         """
         return self._make_request("POST", f"resources/{kind}/validate", json=resource)
 
-    def get(self, kind: str, id: str) -> Tuple[int, List | str]:
+    def get(self, kind: str, id: str) -> Tuple[int, Union[List, str]]:
         """
         Get resource JSON
         Args:
@@ -133,7 +133,7 @@ class KumaRestAPIResources(KumaRestAPIModule):
         """
         return self._make_request("GET", f"resources/{kind}/{id}")
 
-    def put(self, kind: str, id: str, resource: dict) -> Tuple[int, List | str]:
+    def put(self, kind: str, id: str, resource: dict) -> Tuple[int, Union[List, str]]:
         """
         Modify|Update resource with JSON
         Args:
@@ -143,7 +143,7 @@ class KumaRestAPIResources(KumaRestAPIModule):
         """
         return self._make_request("PUT", f"resources/{kind}/{id}", json=resource)
 
-    def list_history(self, kind: str, id: str) -> Tuple[int, List | str]:
+    def list_history(self, kind: str, id: str) -> Tuple[int, Union[List, str]]:
         """Getting all resource history versions
         id (str): Resource UUID
         kind (str): Resource kind (correlationRule|dictionary|...)
@@ -152,7 +152,7 @@ class KumaRestAPIResources(KumaRestAPIModule):
 
     def get_history(
         self, kind: str, id: str, history_id: int
-    ) -> Tuple[int, List | str]:
+    ) -> Tuple[int, Union[List, str]]:
         """Getting resource history version with specified kind, ID and version number
         id (str): Resource UUID
         kind (str): Resource kind (correlationRule|dictionary|...)
@@ -160,7 +160,7 @@ class KumaRestAPIResources(KumaRestAPIModule):
         """
         return self._make_request("GET", f"resources/{kind}/{id}/history/{history_id}")
 
-    def revert(self, kind: str, id: str, history_id: int) -> Tuple[int, List | str]:
+    def revert(self, kind: str, id: str, history_id: int) -> Tuple[int, Union[List, str]]:
         """Reverting resource history version with specified kind, ID and version number
         id (str): Resource UUID
         kind (str): Resource kind (correlationRule|dictionary|...)

--- a/kuma/rest/services.py
+++ b/kuma/rest/services.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, Union
 
 from kuma.rest._base import KumaRestAPIModule
 
@@ -8,7 +8,7 @@ class KumaRestAPIServices(KumaRestAPIModule):
     def search(
         self,
         **kwargs,
-    ) -> tuple[int, dict | str]:
+    ) -> Tuple[int, Union[dict, str]]:
         """
         Search services with filtering.
         Args:

--- a/kuma/rest/settings.py
+++ b/kuma/rest/settings.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Tuple, Union
 
 from kuma.rest._base import KumaRestAPIModule
 
@@ -6,20 +6,20 @@ from kuma.rest._base import KumaRestAPIModule
 class KumaRestAPISettings(KumaRestAPIModule):
     """Methods for Settings."""
 
-    def export_extendedfields(self) -> tuple[int, dict | str]:
+    def export_extendedfields(self) -> Tuple[int, Union[dict, str]]:
         """
         The user can export a list of fields from the extended event schema.
         """
         return self._make_request("GET", f"settings/extendedFields/export")
 
-    def import_extendedfields(self, fields: List[dict]) -> tuple[int, dict | str]:
+    def import_extendedfields(self, fields: List[dict]) -> Tuple[int, Union[dict, str]]:
         """
         The user can import a list of fields from the extended event schema.
         whats examples examples\import_extended_fields.txt
         """
         return self._make_request("POST", f"settings/extendedFields/import")
 
-    def view(self, id: str) -> tuple[int, dict | str]:
+    def view(self, id: str) -> Tuple[int, Union[dict, str]]:
         """
         List of custom fields added by the KUMA user in the application web interface.
         Args:

--- a/kuma/rest/tasks.py
+++ b/kuma/rest/tasks.py
@@ -1,11 +1,11 @@
-from typing import List, Tuple
+from typing import List, Tuple, Union
 
 from kuma.rest._base import KumaRestAPIModule
 
 
 class KumaRestAPITasks(KumaRestAPIModule):
     """Methods for Tasks."""
-    def create(self, task: dict) -> Tuple[int, List | str]:
+    def create(self, task: dict) -> Tuple[int, Union[List, str]]:
         """
         Search tenants with filter
         Args:

--- a/kuma/rest/tenants.py
+++ b/kuma/rest/tenants.py
@@ -1,11 +1,11 @@
-from typing import List, Tuple
+from typing import List, Tuple, Union
 
 from kuma.rest._base import KumaRestAPIModule
 
 
 class KumaRestAPITenants(KumaRestAPIModule):
     """Methods for Tenants."""
-    def search(self, **kwargs) -> Tuple[int, List | str]:
+    def search(self, **kwargs) -> Tuple[int, Union[List, str]]:
         """
         Search tenants with filter
         Args:
@@ -21,7 +21,7 @@ class KumaRestAPITenants(KumaRestAPIModule):
         name: str,
         eps_limit: int,
         description: str = "",
-    ) -> Tuple[int, List | str]:
+    ) -> Tuple[int, Union[List, str]]:
         """
         Create tenant
         Args:

--- a/kuma/rest/users.py
+++ b/kuma/rest/users.py
@@ -1,11 +1,11 @@
-from typing import List, Tuple
+from typing import List, Tuple, Union
 
 from kuma.rest._base import KumaRestAPIModule
 
 
 class KumaRestAPIUsers(KumaRestAPIModule):
     """Methods for Users."""
-    def search(self, **kwargs) -> Tuple[int, List | str]:
+    def search(self, **kwargs) -> Tuple[int, Union[List, str]]:
         """
         Search tenants with filter
         Args:
@@ -23,7 +23,7 @@ class KumaRestAPIUsers(KumaRestAPIModule):
         params = {**kwargs}
         return self._make_request("GET", "users", params=params)
 
-    def get(self, id: str) -> Tuple[int, List | str]:
+    def get(self, id: str) -> Tuple[int, Union[List, str]]:
         """
         Get specified user by UUID
         Args:
@@ -31,7 +31,7 @@ class KumaRestAPIUsers(KumaRestAPIModule):
         """
         return self._make_request("GET", f"users/id/{id}")
 
-    def whoami(self) -> Tuple[int, List | str]:
+    def whoami(self) -> Tuple[int, Union[List, str]]:
         """
         Show info about token user
         """


### PR DESCRIPTION
## Summary
- replace PEP 604 style union annotations in `kuma/private.py` with `typing.Optional`/`typing.Union` for Python 3.9 compatibility
- update REST API modules to import and use `typing.Union` instead of `|` in return annotations
- added git label for Python3.9

