### PR TITLE
Add API Version Choice

### DIFF
--- a/kuma/rest/__init__.py
+++ b/kuma/rest/__init__.py
@@ -1,4 +1,5 @@
-from typing import Union
+import logging
+from typing import Union, Optional
 
 from kuma.rest._base import KumaRestAPIBase
 from kuma.rest.active_lists import KumaRestAPIActiveLists
@@ -47,8 +48,10 @@ class KumaRestAPI(KumaRestAPIBase):
         token: str,
         verify: Union[bool, str],
         timeout: int = KumaRestAPIBase.DEFAULT_TIMEOUT,
+        logger: Optional[logging.Logger] = None,
+        version: str = "",
     ):
-        super().__init__(url, token, verify, timeout)
+        super().__init__(url, token, verify, timeout, logger, version)
         self._modules = {}
 
     def _get_module(self, name: str):

--- a/kuma/rest/_base.py
+++ b/kuma/rest/_base.py
@@ -34,15 +34,17 @@ class KumaRestAPIBase:
         verify: Union[bool, str] = False,
         timeout: int = DEFAULT_TIMEOUT,
         logger: Optional[logging.Logger] = None,
+        version: str = "",
     ):
         """Initialize the API client.
 
         Args:
-            url: Base server URL (e.g., "kumacore.local" or "https://kumacore.local:7223")
-            token: Bearer token for authentication
+            url: Base server URL (e.g., "kumacore.local" or "https://kumacore.local:7223").
+            token: Bearer token for authentication.
             verify: SSL certificate verification. Set False to disable warnings.
-            timeout: Request timeout in seconds (default: 30)
-            logger: Custom logger instance (optional)
+            timeout: Request timeout in seconds (default: 30).
+            logger: Custom logger instance (optional).
+            version: Version of KUMA API.
 
         Raises:
             ValueError: If URL is malformed
@@ -52,6 +54,7 @@ class KumaRestAPIBase:
 
         self.timeout = timeout
         self.logger = logger or self._create_default_logger()
+        self.v = version or _api_version
 
         self._configure_url(url)
         self._configure_session(token)
@@ -126,7 +129,7 @@ class KumaRestAPIBase:
         """
         Unified request method with error handling and logging.
         """
-        url = f"{self.url}/api/{_api_version}/{endpoint.lstrip('/')}"
+        url = f"{self.url}/api/{self.v}/{endpoint.lstrip('/')}"
         headers = {**self.session.headers, **(headers or {})}
 
         self.logger.debug(f"Request: {method} {url}")


### PR DESCRIPTION
Add ability to choose API version of KUMA.

It can be useful in case of updating resource.

**For example:** updating resource via version 3 will lead to validation error, but updating via version 2.1 will be successful.